### PR TITLE
Dynalab-cli test-local

### DIFF
--- a/dynalab/tasks/__init__.py
+++ b/dynalab/tasks/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Facebook, Inc. and its affiliates.

--- a/dynalab/tasks/common.py
+++ b/dynalab/tasks/common.py
@@ -1,0 +1,24 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+import os
+
+from ts.context import Context
+
+from dynalab_cli.utils import SetupConfigHandler
+
+
+def get_mock_context(model_name):
+    config_handler = SetupConfigHandler(model_name)
+    config = config_handler.load_config()
+    fname = os.path.basename(config["checkpoint"])
+    model_dir = os.path.dirname(config["checkpoint"])
+    manifest = {"model": {"serializedFile": fname}}
+    context = Context(
+        model_name=model_name,
+        model_dir=model_dir,
+        manifest=manifest,
+        batch_size=1,
+        gpu=False,
+        mms_version=None,
+    )
+    return context

--- a/dynalab/tasks/hate_speech.py
+++ b/dynalab/tasks/hate_speech.py
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from ts.torch_handler.base_handler import BaseHandler
+
+from dynalab.tasks.common import get_mock_context
+
+
+data = [
+    {
+        "body": {
+            "context": "Please provide a hateful or not hateful statement",
+            "hypothesis": "It is a good day",
+            "target": 0,
+        }
+    }
+]
+
+
+def get_mock_input(name):
+    context = get_mock_context(name)
+    return data, context
+
+
+# To be filled
+class DynaHandler(BaseHandler):
+    pass

--- a/dynalab/tasks/nli.py
+++ b/dynalab/tasks/nli.py
@@ -1,0 +1,36 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from ts.torch_handler.base_handler import BaseHandler
+
+from dynalab.tasks.common import get_mock_context
+
+
+data = [
+    {
+        "body": {
+            "context": "Old Trafford is a football stadium "
+            + " in Old Trafford, "
+            + "Greater Manchester, England, and the home of "
+            + "Manchester United. "
+            + "With a capacity of 75,643, it is the largest club football "
+            + "stadium in the United Kingdom, the second-largest football "
+            + "stadium, and the eleventh-largest in Europe. "
+            + "It is about 0.5 mi from Old Trafford Cricket Ground"
+            + " and the adjacent tram stop.",
+            "hypothesis": "There is no club football stadium in "
+            + "England larger "
+            + "than the one in Manchester.",
+            "target": 0,
+        }
+    }
+]
+
+
+def get_mock_input(name):
+    context = get_mock_context(name)
+    return data, context
+
+
+# To be filled
+class DynaHandler(BaseHandler):
+    pass

--- a/dynalab/tasks/qa.py
+++ b/dynalab/tasks/qa.py
@@ -1,0 +1,27 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from ts.torch_handler.base_handler import BaseHandler
+
+from dynalab.tasks.common import get_mock_context
+
+
+data = [
+    {
+        "body": {
+            "answer": "pretend you are reviewing a place",
+            "context": "Please pretend you are reviewing a place, "
+            + "product, book or movie",
+            "hypothesis": "What should i pretend?",
+        }
+    }
+]
+
+
+def get_mock_input(name):
+    context = get_mock_context(name)
+    return data, context
+
+
+# To be filled
+class DynaHandler(BaseHandler):
+    pass

--- a/dynalab/tasks/sentiment.py
+++ b/dynalab/tasks/sentiment.py
@@ -1,0 +1,27 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from ts.torch_handler.base_handler import BaseHandler
+
+from dynalab.tasks.common import get_mock_context
+
+
+data = [
+    {
+        "body": {
+            "context": "Please pretend you a reviewing a place, "
+            + "product, book or movie.",
+            "hypothesis": "It is a good day",
+            "target": 0,
+        }
+    }
+]
+
+
+def get_mock_input(name):
+    context = get_mock_context(name)
+    return data, context
+
+
+# To be filled
+class DynaHandler(BaseHandler):
+    pass

--- a/dynalab_cli/main.py
+++ b/dynalab_cli/main.py
@@ -3,10 +3,16 @@
 from argparse import ArgumentParser
 
 from dynalab_cli.init import InitCommand
+from dynalab_cli.test import TestCommand
 from dynalab_cli.user import LoginCommand, LogoutCommand
 
 
-command_map = {"login": LoginCommand, "logout": LogoutCommand, "init": InitCommand}
+command_map = {
+    "login": LoginCommand,
+    "logout": LogoutCommand,
+    "init": InitCommand,
+    "test": TestCommand,
+}
 
 
 def main():
@@ -16,6 +22,7 @@ def main():
     LoginCommand.add_args(subparsers)
     LogoutCommand.add_args(subparsers)
     InitCommand.add_args(subparsers)
+    TestCommand.add_args(subparsers)
 
     args = parser.parse_args()
 

--- a/dynalab_cli/test.py
+++ b/dynalab_cli/test.py
@@ -1,0 +1,92 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import os
+import subprocess
+
+from dynalab_cli import BaseCommand
+from dynalab_cli.utils import SetupConfigHandler
+
+
+MAX_SIZE = 2 * 1024 * 1024 * 1024  # 2GB
+
+
+class TestCommand(BaseCommand):
+    @staticmethod
+    def add_args(parser):
+        test_parser = parser.add_parser(
+            "test", help="Check files and test code in local environment"
+        )
+        test_parser.add_argument(
+            "-n", "--name", type=str, required=True, help="Name of the model"
+        )
+        test_parser.add_argument(
+            "--local", action="store_true", help="whether to run local test only"
+        )
+
+    def __init__(self, args):
+        self.args = args
+        self.config_handler = SetupConfigHandler(args.name)
+
+    def run_command(self):
+        # Validate config file: all keys exist, required values specified,
+        # all specified files exist, handler files in the same directory as handler,
+        # and handler file inherits from the correct base handler
+        try:
+            self.config_handler.validate_config()
+            print("Config file validated.")
+        except AssertionError as err:
+            print(
+                f"Error: {err}.\nPlease fix your config file by",
+                "dynalab-cli init --amend",
+            )
+            exit(1)
+
+        config = self.config_handler.load_config()
+
+        # Check file size and ask to exclude large files
+        total_size = 0
+        for dentry in os.scandir("."):
+            total_size += dentry.stat().st_size
+        if config["exclude"]:
+            for f in config["exclude"].split(","):
+                total_size -= os.path.getsize(f)
+        if total_size > MAX_SIZE:
+            print(
+                "Warning: Size of current project folder is more than 2GB. "
+                "Please consider add large files or folders to exclude"
+            )
+
+        test_handler = self.compose_test_handler_file(config)
+        subprocess.run(["python", test_handler])
+
+        if not self.args.local:
+            # pull docker
+            pass
+
+    def compose_test_handler_file(self, config):
+        test_handler = os.path.join(
+            self.config_handler.config_dir, "tmp", "test_handler.py"
+        )
+        os.makedirs(os.path.join(self.config_handler.config_dir, "tmp"), exist_ok=True)
+
+        handler_dir = os.path.join(".", os.path.dirname(config["handler"]))
+        handler_name = os.path.splitext(os.path.basename(config["handler"]))[0]
+
+        import_handler_command = (
+            f"import sys\nsys.path.append('{handler_dir}')\n"
+            f"handler = __import__('{handler_name}')\n"
+        )
+        import_context_command = (
+            f"from dynalab.tasks.{config['task']} import get_mock_input\n"
+        )
+
+        run_command = (
+            f"if __name__ == '__main__':\n"
+            f"    data, context = get_mock_input('{self.args.name}')\n"
+            f"    handler.handle(data=data, context=context)\n"
+            f"    print('Local test passed')\n"
+        )
+        with open(test_handler, "w+") as f:
+            f.write(import_handler_command)
+            f.write(import_context_command)
+            f.write(run_command)
+        return test_handler

--- a/dynalab_cli/utils.py
+++ b/dynalab_cli/utils.py
@@ -72,12 +72,49 @@ def get_tasks():
     return tasks
 
 
+# some file path utils
+def check_path(path, root_dir=".", is_file=True, allow_empty=True):
+    if not path:
+        return False
+    if not os.path.exists(path):
+        return False
+    if is_file and not os.path.isfile(path):
+        return False
+    if not allow_empty and os.path.getsize(path) == 0:
+        return False
+    return os.path.realpath(path).startswith(os.path.realpath(root_dir))
+
+
+def get_path_inside_rootdir(path, root_dir="."):
+    realpath = os.path.realpath(os.path.expanduser(path))
+    return realpath[len(os.path.realpath(root_dir)) :].lstrip("/")
+
+
+def default_filename(key):
+    if key in ("handler", "setup"):
+        return key + ".py"
+    if key == "checkpoint":
+        return key + ".pt"
+    if key == "requirements":
+        return key + ".txt"
+    raise NotImplementedError
+
+
 # TODO: WIP
 class SetupConfigHandler:
     def __init__(self, name):
         self.name = name
         self.config_path = f"./.dynalab/{self.name}/setup_config.json"
         self.config_dir = os.path.dirname(self.config_path)
+        self.config_fields = {
+            "task",
+            "checkpoint",
+            "handler",
+            "requirements",
+            "setup",
+            "model_files",
+            "exclude",
+        }
 
     def config_exists(self):
         return os.path.exists(self.config_path)
@@ -87,9 +124,74 @@ class SetupConfigHandler:
             with open(self.config_path) as f:
                 return json.load(f)
         else:
-            raise RuntimeError(f"Please call dynalab-cli init to initiate this repo. ")
+            raise RuntimeError(
+                f"No config found. Please call dynalab-cli init to initiate this repo. "
+            )
 
     def write_config(self, config):
         os.makedirs(self.config_dir, exist_ok=True)
         with open(self.config_path, "w+") as f:
             f.write(json.dumps(config, indent=4))
+
+    def validate_config(self):
+        config = self.load_config()
+        contained_fields = set()
+        key = "exclude"
+        assert key in config, f"Missing config field {key}"
+        excluded_files = set()
+        if config[key]:
+            files = config[key].strip(", ").split(",")
+            for f in files:
+                assert check_path(
+                    f, is_file=False, allow_empty=False
+                ), f"{f} is empty or not a valid path"
+                excluded_files.add(get_path_inside_rootdir(f))
+            config[key] = ",".join(excluded_files)
+        for key in config.keys():
+            assert key in self.config_fields, f"Invalid config field {key}"
+            assert key not in contained_fields, f"Repeated config field {key}"
+            contained_fields.add(key)
+            if key == "task":
+                assert config[key] in get_tasks(), f"Invalid task name {config[key]}"
+            elif key in ("checkpoint", "handler"):
+                assert check_path(
+                    config[key], allow_empty=False
+                ), f"{config[key]} is empty or not a valid path"
+                f = get_path_inside_rootdir(config[key])
+                assert f not in excluded_files, f"{key} file {f} cannot be excluded"
+                if key == "handler":
+                    assert f.endswith(".py"), f"Handler must be a Python file"
+                config[key] = f
+            elif key == "model_files":
+                if config[key]:
+                    handler_dir = os.path.dirname(os.path.realpath(config["handler"]))
+                    files = config[key].strip(", ").split(",")
+                    formated_files = set()
+                    for f in files:
+                        assert check_path(
+                            f, allow_empty=False
+                        ), f"{f} is empty or not a valid path"
+                        f = get_path_inside_rootdir(f)
+                        assert os.path.dirname(os.path.realpath(f)) == handler_dir, (
+                            f"Model files {f} not under the same level "
+                            "as handler file {config['handler']}"
+                        )
+                        assert (
+                            f not in excluded_files
+                        ), f"{key} file {f} cannot be excluded"
+                        formated_files.add(f)
+                    config[key] = ",".join(formated_files)
+            elif key in ("requirements", "setup"):
+                assert isinstance(
+                    config[key], bool
+                ), f"{key.capitalize()} field must be a boolean true/false"
+                if config[key]:
+                    assert check_path(default_filename(key), allow_empty=False), (
+                        f"Cannot install {key} without or with empty "
+                        "./{default_filename(key)}"
+                    )
+
+        for field in self.config_fields:
+            assert field in contained_fields, f"Missing config field {key}"
+
+        self.write_config(config)


### PR DESCRIPTION
Review notes: **No need to look at init.py - I just moved some functions to utils.py**. 

**A proposed change in interface design**:
- original design: dynalab-cli test-local -n <name>
- new design: dynalab-cli test -n <name> --local
- rationale: `test` command involves running `test-local` so it's probably easier to combine them together.

**test --local will do three things**:
1. Validate the setup_config, including: all fields existing, all file paths are correct, handler/checkpoint/etc. files are not excluded. etc. 
2. Make sure total size of the folder, excluding files to be excluded, is less than 2GB (we can change this limit)
3. Compose a `.dynalab/<model_name>/tmp/test_handler.py` file that will import mock data and context from the task, and run the handler. This `tmp` folder will hold dockerfile too, and will be excluded in upload. **Alternative to composing test_handler on the go (since Python is vulnerable to indent error): have a test_handler.py template on e.g. S3, download that to tmp folder and pass task name as an argument**. 


**The assumption on the handler file (in exactly the same handler file format as what we have in dynabench now):**
```
class ThisModelHandler(BaseTaskHandler):
    def __init__(self):
    def initialize(self, context):
    def preprocess(self, data):
    def inference(self, **args):
    def postprocess(self, **args)

_service = ThisModelHandler() # any name as long as the class is instantiated
def handle(data, context):
    _service.<func>()
```
