### PR TITLE
[feat] API token based authentication

### DIFF
--- a/dynalab/config.py
+++ b/dynalab/config.py
@@ -1,3 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 DYNABENCH_API = "https://api.dynabench.org"
+DYNABENCH_WEB = "http://dynabench.org"


### PR DESCRIPTION
- To use the api, user must login first using `dynalab-cli login` and
  then internally, we can use `AccessToken.headers` property to get
authorization headers for their requests request
- Depends on facebookresearch/dynabench#74