### PR TITLE
Fix extra-file path assertion in dynalab-cli init

### DIFF
--- a/dynalab_cli/init.py
+++ b/dynalab_cli/init.py
@@ -83,8 +83,9 @@ class InitCommand(BaseCommand):
             default="",
             help=(
                 "Comma separated list of files that defines the model, "
-                "e.g. vocabulary, config. Note that these files must be under the same "
-                "parent directory as the handler file"
+                "e.g. vocabulary, config. Once added here, you can directly "
+                "import or read these files by name in your handler file "
+                "without specifying paths. "
             ),
         )
         init_parser.add_argument(

--- a/dynalab_cli/utils.py
+++ b/dynalab_cli/utils.py
@@ -229,18 +229,12 @@ class SetupConfigHandler:
                 config[key] = f
             elif key == "model_files":
                 if config[key]:
-                    handler_dir = os.path.dirname(os.path.realpath(config["handler"]))
                     files = config[key].strip(", ").split(",")
                     formated_files = set()
                     for f in files:
                         assert check_path(
                             f, allow_empty=False
                         ), f"{f} is empty or not a valid path"
-                        f = get_path_inside_rootdir(f)
-                        assert os.path.dirname(os.path.realpath(f)) == handler_dir, (
-                            f"Model files {f} not under the same level "
-                            "as handler file {config['handler']}"
-                        )
                         assert (
                             f not in excluded_files
                         ), f"{key} file {f} cannot be excluded"


### PR DESCRIPTION
In short extra files do not need to be under the same directory as handler file, but they will be moved into the same directory as handler when serving in torchserve. 

For more details, please see my description in https://github.com/fairinternal/dynalab/issues/17