### PR TITLE
Dynalab-cli init --amend to modify config using default editor

### DIFF
--- a/dynalab_cli/utils.py
+++ b/dynalab_cli/utils.py
@@ -247,7 +247,7 @@ class SetupConfigHandler:
                 if config[key]:
                     assert check_path(default_filename(key), allow_empty=False), (
                         f"Cannot install {key} without or with empty "
-                        "./{default_filename(key)}"
+                        f"./{default_filename(key)}"
                     )
 
         for field in self.config_fields:


### PR DESCRIPTION
To close https://github.com/fairinternal/dynalab/issues/4. Also removed all empty lines that separates blocks since prompts look pretty short now.

Example prompt at init: 

```
mazhiyi@mazhiyi-mbp ~/Documents/Projects/DYNABENCH/test_test_project [master *]
± % dynalab-cli init -n nli-model                                                                                                                                                                             !9286
Folder . already initialized for model 'nli-model'. Overwrite? [Y/n] y
Initializing . for dynalab model 'nli-model'...
Please choose a valid task name from one of [sentiment, qa, nli, hate_speech]: nli
Checkpoint file ./checkpoint.pt not a valid path. Please re-specify path to checkpoint file inside the root dir: models/checkpoint.pt
Handler file found at ./handler.py. Press enter, or specify alternative path [./handler.py]:
Requirements file found. Do you want us to install dependencies using ./requirements.txt? [Y/n] y
No model_files path specified. You can provide paths by using dynalab-cli init --amend
No exclude path specified. You can provide paths by using dynalab-cli init --amend
Done
```

To amend: 
```
mazhiyi@mazhiyi-mbp ~/Documents/Projects/DYNABENCH/test_test_project [master *]
± % dynalab-cli init -n nli-model --amend
```
The default editor will open the corresponding setup_config file. After it is written, if the config is still wrong, user will get prompts like 
```
mazhiyi@mazhiyi-mbp ~/Documents/Projects/DYNABENCH/test_test_project [master *]
± % dynalab-cli init -n nli-model --amend                                                                                                                                                                     !9287
Validating the updated config...
Traceback (most recent call last):
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/init.py", line 127, in run_command
    self.config_handler.validate_config()
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/utils.py", line 249, in validate_config
    f"Cannot install {key} without or with empty "
AssertionError: Cannot install setup without or with empty ./setup.py

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mazhiyi/anaconda3/envs/dynabench/bin/dynalab-cli", line 33, in <module>
    sys.exit(load_entry_point('dynalab', 'console_scripts', 'dynalab-cli')())
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/main.py", line 32, in main
    command_map[args.option](args).run_command()
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/init.py", line 130, in run_command
    f"Validation failed: {e}. "
RuntimeError: Validation failed: Cannot install setup without or with empty ./setup.py. Please update this field with dynalab-cli init --amend
```
And you cannot amend a config that doesn't exist:
```
mazhiyi@mazhiyi-mbp ~/Documents/Projects/DYNABENCH/test_test_project [master *]
± % dynalab-cli init -n nli-model-non-exist --amend                                                                                                                                                           !9288
Traceback (most recent call last):
  File "/Users/mazhiyi/anaconda3/envs/dynabench/bin/dynalab-cli", line 33, in <module>
    sys.exit(load_entry_point('dynalab', 'console_scripts', 'dynalab-cli')())
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/main.py", line 32, in main
    command_map[args.option](args).run_command()
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/init.py", line 122, in run_command
    raise RuntimeError("Please run dynalab-cli init first")
RuntimeError: Please run dynalab-cli init first
```