### PR TITLE
Set PYTHONIOENCODING to UTF-8 explicitly in docker file

### DIFF
--- a/dynalab/dockerfiles/Dockerfile.dev
+++ b/dynalab/dockerfiles/Dockerfile.dev
@@ -44,4 +44,5 @@ RUN if [ -f code/requirements.txt ] && [ ${requirements} = True ]; then pip inst
 RUN if [ -f code/setup.py ] && [ ${setup} = True ]; then pip install --no-cache-dir -e code; fi
 
 ENV model_name=${model_name}
+ENV PYTHONIOENCODING=UTF-8
 ENTRYPOINT /usr/local/bin/dev-entrypoint.sh ${model_name}

--- a/dynalab/dockerfiles/prod/Dockerfile
+++ b/dynalab/dockerfiles/prod/Dockerfile
@@ -38,5 +38,6 @@ ADD ${tarball_name}.tar.gz /home/model-server/code
 RUN if [ -f code/requirements.txt ] && [ ${requirements} = True ]; then pip install --no-cache-dir -r code/requirements.txt; fi
 RUN if [ -f code/setup.py ] && [ ${setup} = True ]; then pip install --no-cache-dir -e code; fi
 
+ENV PYTHONIOENCODING=UTF-8
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
 CMD ["serve"]


### PR DESCRIPTION
For an example like 
```
data = {
    "uid": "107792n", 
    "context": "hackamore from j?\u00a1quima; mustang from mestengo", 
    "hypothesis": "Many items were named after Mexican words, like chupacabra. ", "label": "n"}
```

`print(data)` will fail with `UnicodeEncodeError: 'ascii' codec can't encode character '\xa1' in position 17: ordinal not in range(128)` without this setting explicitly.  

----
Going forward, if future datasets use character sets beyond UTF-8, they should always supply such an example for local test - next PR I'll make local test support multiple input examples by default. 