### PR TITLE
[Optimization] Do not include checkpoint in docker image since it is in the model archive

### DIFF
--- a/dynalab_cli/init.py
+++ b/dynalab_cli/init.py
@@ -245,6 +245,7 @@ class InitCommand(BaseCommand):
                 f"No {key} path specified. You can "
                 f"provide paths by using dynalab-cli init --amend"
             )
+            value = []
         else:
             missing = self.missing_file(key, value.strip(", ").split(","))
             while missing:
@@ -263,7 +264,7 @@ class InitCommand(BaseCommand):
                 get_path_inside_rootdir(f, root_dir=self.root_dir)
                 for f in value.strip(", ").split(",")
             ]
-            value = ",".join([f for f in files if f])
+            value = [f for f in files if f]
         self.update_field(key, value)
 
     def create_file(self, key):

--- a/dynalab_cli/test.py
+++ b/dynalab_cli/test.py
@@ -50,7 +50,7 @@ class TestCommand(BaseCommand):
         for dentry in os.scandir("."):
             total_size += dentry.stat().st_size
         if config["exclude"]:
-            for f in config["exclude"].split(","):
+            for f in config["exclude"]:
                 total_size -= os.path.getsize(f)
         if total_size > MAX_SIZE:
             print(
@@ -66,18 +66,14 @@ class TestCommand(BaseCommand):
             os.makedirs(tmp_dir, exist_ok=True)
             # tarball everything
             print("Tarballing the project directory...")
-            with open(os.path.join(tmp_dir, "exclude.txt"), "w+") as f:
-                if config["exclude"]:
-                    for ex in config["exclude"].split(","):
-                        f.write(ex + "\n")
-                for m in os.listdir(".dynalab"):
-                    if m != self.args.name:
-                        f.write(os.path.join(".dynalab", m) + "\n")
-                f.write(tmp_dir)
+            exclude_list_file = os.path.join(tmp_dir, "exclude.txt")
+            self.config_handler.write_exclude_filelist(
+                exclude_list_file, self.args.name, exclude_model=True
+            )
             process = subprocess.run(
                 [
                     "tar",
-                    f"--exclude-from={os.path.join(tmp_dir, 'exclude.txt')}",
+                    f"--exclude-from={exclude_list_file}",
                     "-czf",
                     os.path.join(tmp_dir, f"{self.args.name}.tar.gz"),
                     ".",
@@ -108,7 +104,7 @@ class TestCommand(BaseCommand):
                 tmp_dir,
             ]
             if config["model_files"]:
-                archive_command += ["--extra-files", config["model_files"]]
+                archive_command += ["--extra-files", ",".join(config["model_files"])]
             process = subprocess.run(
                 archive_command,
                 stdout=subprocess.PIPE,

--- a/dynalab_cli/upload.py
+++ b/dynalab_cli/upload.py
@@ -32,22 +32,12 @@ class UploadCommand(BaseCommand):
         tarball = f"{self.args.name}.tar.gz"
         tmp_dir = os.path.join(".dynalab", self.args.name, "tmp")
         os.makedirs(tmp_dir, exist_ok=True)
-        with open(os.path.join(tmp_dir, "exclude.txt"), "w+") as f:
-            if config["exclude"]:
-                for ex in config["exclude"].split(","):
-                    f.write(ex + "\n")
-            for m in os.listdir(".dynalab"):
-                if m != self.args.name:
-                    f.write(os.path.join(".dynalab", m) + "\n")
-            f.write(tmp_dir)
+        exclude_list_file = os.path.join(tmp_dir, "exclude.txt")
+        self.config_handler.write_exclude_filelist(
+            exclude_list_file, self.args.name, exclude_model=False
+        )
         process = subprocess.run(
-            [
-                "tar",
-                f"--exclude-from={os.path.join(tmp_dir, 'exclude.txt')}",
-                "-czf",
-                tarball,
-                ".",
-            ],
+            ["tar", f"--exclude-from={exclude_list_file}", "-czf", tarball, "."],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,

--- a/dynalab_cli/utils.py
+++ b/dynalab_cli/utils.py
@@ -206,7 +206,7 @@ class SetupConfigHandler:
         assert key in config, f"Missing config field {key}"
         excluded_files = set()
         if config[key]:
-            files = config[key].strip(", ").split(",")
+            files = config[key]
             for f in files:
                 assert check_path(
                     os.path.join(self.root_dir, f),
@@ -235,7 +235,7 @@ class SetupConfigHandler:
                     assert config[key].endswith(".py"), f"Handler must be a Python file"
             elif key == "model_files":
                 if config[key]:
-                    files = config[key].split(",")
+                    files = config[key]
                     for f in files:
                         assert check_path(
                             os.path.join(self.root_dir, f),
@@ -261,3 +261,29 @@ class SetupConfigHandler:
 
         for field in self.config_fields:
             assert field in contained_fields, f"Missing config field {key}"
+
+    def write_exclude_filelist(self, outfile, model_name, exclude_model=False):
+        config = self.load_config()
+        with open(outfile, "w") as f:
+            # all exclude files and folders
+            if config["exclude"]:
+                for ex in config["exclude"]:
+                    f.write(ex + "\n")
+
+            # tmp dir for test
+            tmp_dir = os.path.join(self.config_dir, "tmp")
+            if os.path.exists(os.path.join(self.root_dir, tmp_dir)):
+                f.write(tmp_dir + "\n")
+
+            # dir for other models
+            dynalab_dir = ".dynalab"
+            if os.path.exists(os.path.join(self.root_dir, dynalab_dir)):
+                for m in os.listdir(dynalab_dir):
+                    if m != model_name:
+                        f.write(m + "\n")
+
+            f.write(outfile + "\n")
+
+            if exclude_model:
+                f.write(config["checkpoint"] + "\n")
+                f.write(config["handler"] + "\n")


### PR DESCRIPTION
And a BE fix to make files in setup config a list rather than string

linked to Dynabench: https://github.com/facebookresearch/dynabench/pull/378

While my model is only 1.6K out of 16M total folder size, on ECR my docker size reduced from 1352MB to 1335MB, i.e. roughly 20MB save for 1.6K checkpoint. The save should be much more significant for a real model. 

---
Update: dynalab models tend to have docker size ~1GB vs target model docker ~4GB for a similar model. 