### PR TITLE
Remove internet access in docker at integrated test

### DIFF
--- a/dynalab_cli/test.py
+++ b/dynalab_cli/test.py
@@ -155,7 +155,7 @@ class TestCommand(BaseCommand):
 
             subprocess.run(docker_build_command)
             process = subprocess.run(
-                f"docker run {repository_name}",
+                f"docker run --network none {repository_name}",
                 shell=True,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,


### PR DESCRIPTION
I wrote this in my handler: 
```
        try:
            r = requests.get("https://api.dynabench.org/tasks")
            r.raise_for_status()
        except requests.exceptions.ConnectionError as ex:
            print(f"No Internet connection! {ex}")
        else:
            print(r.json())
```
and saw this in the output log which means no internet is available in the docker. Still the integrated test itself succeeded without problem. 
```
No Internet connection! HTTPSConnectionPool(host='api.dynabench.org', port=443): Max retries exceeded with          url: /tasks (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fc627d5b0b8>: Failed to establish a new connection:         [Errno -3] Temporary failure in name resolution',))
```