### PR TITLE
[feat] dynalab-cli rename model 

### DIFF
--- a/dynalab_cli/init.py
+++ b/dynalab_cli/init.py
@@ -98,6 +98,12 @@ class InitCommand(BaseCommand):
             "--amend", action="store_true", help="Update the config"
         )
 
+        init_parser.add_argument(
+            "--rename",
+            type=model_name_type,
+            help="Rename an existing model to a new name",
+        )
+
     def __init__(self, args):
         self.args = args
 
@@ -114,6 +120,28 @@ class InitCommand(BaseCommand):
         self.config = {}
 
     def run_command(self):
+        if self.args.rename:
+            if not self.config_handler.config_exists():
+                raise RuntimeError(
+                    f"Model {self.args.name} not found. "
+                    f"Unable to rename a non-existing model. "
+                )
+            else:
+                if os.path.exists(
+                    os.path.join(self.work_dir, ".dynalab", self.args.rename)
+                ):
+                    raise RuntimeError(
+                        f"Model {self.args.rename} already exists. "
+                        f"Unable to rename {self.args.name} to {self.args.rename}"
+                    )
+                else:
+                    os.rename(
+                        os.path.join(self.work_dir, ".dynalab", self.args.name),
+                        os.path.join(self.work_dir, ".dynalab", self.args.rename),
+                    )
+                    print(f"Renamed model {self.args.name} to {self.args.rename}")
+            return
+
         if self.args.amend:
             if not self.config_handler.config_exists():
                 raise RuntimeError("Please run dynalab-cli init first")
@@ -128,6 +156,7 @@ class InitCommand(BaseCommand):
                     "Please update this field with dynalab-cli init --amend"
                 )
             return
+
         if self.config_handler.config_exists():
             ops = input(
                 f"Folder {self.work_dir} already initialized for "


### PR DESCRIPTION
Various error output and a successful log 

```
mazhiyi@mazhiyi-mbp ~/Documents/Projects/DYNABENCH/test-handler [master *]
± % dynalab-cli init -n zm-test-network --rename test-1                                                                                                          !6360
Traceback (most recent call last):
  File "/Users/mazhiyi/Tools/anaconda3/envs/dynabench/bin/dynalab-cli", line 33, in <module>
    sys.exit(load_entry_point('dynalab', 'console_scripts', 'dynalab-cli')())
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/main.py", line 32, in main
    command_map[args.option](args).run_command()
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/init.py", line 126, in run_command
    raise RuntimeError(f"Model {self.args.rename} already exists. Unable to rename {self.args.name} to {self.args.rename}")
RuntimeError: Model test-1 already exists. Unable to rename zm-test-network to test-1
(dynabench) 
mazhiyi@mazhiyi-mbp ~/Documents/Projects/DYNABENCH/test-handler [master *]
± % dynalab-cli init -n zm-test-network- --rename test-2                                                                                                         !6360
Traceback (most recent call last):
  File "/Users/mazhiyi/Tools/anaconda3/envs/dynabench/bin/dynalab-cli", line 33, in <module>
    sys.exit(load_entry_point('dynalab', 'console_scripts', 'dynalab-cli')())
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/main.py", line 32, in main
    command_map[args.option](args).run_command()
  File "/Users/mazhiyi/Documents/Projects/DYNABENCH/dynalab/dynalab_cli/init.py", line 123, in run_command
    raise RuntimeError(f"Model {self.args.name} not found. Unable to rename a non-existing model. ")
RuntimeError: Model zm-test-network- not found. Unable to rename a non-existing model. 
(dynabench) 
mazhiyi@mazhiyi-mbp ~/Documents/Projects/DYNABENCH/test-handler [master *]
± % dynalab-cli init -n zm-test-network --rename test-2                                                                                                          !6361
Renamed model zm-test-network to test-2
```