### PR TITLE
Pass advanced config to torchserve in integrated test to add flexibility for future integrated test optimizations

### DIFF
--- a/dynalab/dockerfiles/Dockerfile.dev
+++ b/dynalab/dockerfiles/Dockerfile.dev
@@ -29,6 +29,7 @@ RUN python -m pip install --no-cache-dir torchserve
 RUN python -m pip install --no-cache-dir torch==1.7.1
 
 COPY ${add_dir}/dev-docker-entrypoint.sh /usr/local/bin/dev-entrypoint.sh
+COPY ${add_dir}/config.properties /usr/local/bin/config.properties
 RUN chmod +x /usr/local/bin/dev-entrypoint.sh
 
 RUN mkdir -p /opt/ml/model

--- a/dynalab/dockerfiles/config.properties
+++ b/dynalab/dockerfiles/config.properties
@@ -1,0 +1,6 @@
+inference_address=http://0.0.0.0:8080
+management_address=http://0.0.0.0:8081
+number_of_netty_threads=32
+job_queue_size=1000
+model_store=/opt/ml/model
+load_models=all

--- a/dynalab/dockerfiles/dev-docker-entrypoint.sh
+++ b/dynalab/dockerfiles/dev-docker-entrypoint.sh
@@ -13,7 +13,7 @@ set -m
 
 # start torchserve
 echo "Start serving model..."
-torchserve --start --ncs --models ${model_name}.mar --model-store /opt/ml/model 1>&2 &
+torchserve --start --ncs --ts-config /usr/local/bin/config.properties 1>&2 &
 
 # health ping to make sure the http connection is on
 echo "Check model loading status..."

--- a/dynalab_cli/test.py
+++ b/dynalab_cli/test.py
@@ -127,6 +127,10 @@ class TestCommand(BaseCommand):
                 os.path.join(lib_dir, "dev-docker-entrypoint.sh"),
                 os.path.join(tmp_dir, "dev-docker-entrypoint.sh"),
             )
+            shutil.copyfile(
+                os.path.join(lib_dir, "config.properties"),
+                os.path.join(tmp_dir, "config.properties"),
+            )
 
             # build docker
             repository_name = self.args.name.lower()


### PR DESCRIPTION
**No functionality change from this PR** Just to enable passing advanced configs in integrated test, so we can tune stuff easier in the future. 

I don't fully understand the impact of `default_workers_per_model` on inference yet, although it seems to be the main reason of memory explosion at model loading time. 