### PR TITLE
Check model name type at rename

### DIFF
--- a/dynalab_cli/init.py
+++ b/dynalab_cli/init.py
@@ -131,6 +131,7 @@ class InitCommand(BaseCommand):
                     f"Unable to rename a non-existing model. "
                 )
             else:
+                check_model_name(self.args.rename)
                 if os.path.exists(
                     os.path.join(self.work_dir, ".dynalab", self.args.rename)
                 ):


### PR DESCRIPTION
Currently we check model name type at init time. 

This PR also adds name checking at rename time. 


```
  % dynalab-cli init -n zm-test-os --rename Bad                          !10025
usage: dynalab-cli init [-h] -n NAME
                        [-t {nli,qa,sentiment,hs,flores_small1,flores_small2,flores_full}]
                        [-d ROOT_DIR] [--model-checkpoint MODEL_CHECKPOINT]
                        [--handler HANDLER] [-r] [--run-setup]
                        [--model-files MODEL_FILES] [--exclude EXCLUDE]
                        [--amend] [--rename RENAME]
dynalab-cli init: error: argument --rename: invalid model_name_type value: 'Bad'
```