### PR TITLE
Fixing `KeyError` that occurs when calling `get_task_submission_limit` 

### DIFF
--- a/dynalab_cli/utils.py
+++ b/dynalab_cli/utils.py
@@ -126,14 +126,11 @@ def get_task_submission_limit(task_code):
     r.raise_for_status()
     for task in r.json():
         if task["task_code"] == task_code:
-            if task["settings_json"] is not None:
-                settings = json.loads(task["settings_json"])
-                return (
-                    settings.get("dynalab_hr_diff", hr_diff),
-                    settings.get("dynalab_threshold", threshold),
-                )
-            else:
-                return hr_diff, threshold
+            if task["dynalab_hr_diff"] is not None:
+                hr_diff = task["dynalab_hr_diff"]
+            if task["dynalab_threshold"] is not None:
+                threshold = task['dynalab_threshold']
+            return hr_diff, threshold
     return hr_diff, threshold
 
 


### PR DESCRIPTION
See #116 