### PR TITLE
Migrate path operations from `os.path` to `pathlib`

### DIFF
--- a/dynalab_cli/init.py
+++ b/dynalab_cli/init.py
@@ -118,9 +118,9 @@ class InitCommand(BaseCommand):
         self.work_dir = Path(args.root_dir)
         self.root_dir = Path(args.root_dir).expanduser().resolve()  # full path
         while not self.root_dir.exists():
-            self.work_dir = Path(input(
-                f"Please input a valid root path to your repo: "
-            ))  # user typed path
+            self.work_dir = Path(
+                input(f"Please input a valid root path to your repo: ")
+            )  # user typed path
             self.root_dir = Path(self.work_dir).expanduser().resolve()
         self.config_handler = SetupConfigHandler(args.name)
         self.config = {}
@@ -134,13 +134,21 @@ class InitCommand(BaseCommand):
                 )
             else:
                 check_model_name(self.args.rename)
-                if (self.work_dir / self.config_handler.dynalab_dir / self.args.rename).exists():
+                if (
+                    self.work_dir / self.config_handler.dynalab_dir / self.args.rename
+                ).exists():
                     raise RuntimeError(
                         f"Model {self.args.rename} already exists. "
                         f"Unable to rename {self.args.name} to {self.args.rename}"
                     )
                 else:
-                    (self.work_dir / self.config_handler.dynalab_dir / self.args.name).rename(self.work_dir / self.config_handler.dynalab_dir / self.args.rename)
+                    (
+                        self.work_dir / self.config_handler.dynalab_dir / self.args.name
+                    ).rename(
+                        self.work_dir
+                        / self.config_handler.dynalab_dir
+                        / self.args.rename
+                    )
                     print(f"Renamed model {self.args.name} to {self.args.rename}")
             return
 
@@ -211,7 +219,11 @@ class InitCommand(BaseCommand):
 
         task_info = {"annotation_config": annotation_config, "task": value}
 
-        task_info_path = self.config_handler.root_dir / self.config_handler.dynalab_dir / f"{value}.json"
+        task_info_path = (
+            self.config_handler.root_dir
+            / self.config_handler.dynalab_dir
+            / f"{value}.json"
+        )
 
         task_io_dir = task_info_path.parent
         task_io_dir.mkdir(exist_ok=True)
@@ -319,7 +331,12 @@ class InitCommand(BaseCommand):
             if ops.strip().lower() not in ("y", "yes"):
                 return None
         if key == "handler":
-            template = Path(__file__).resolve().parent.parent / "dynalab" / "handler" / "handler.py.template"
+            template = (
+                Path(__file__).resolve().parent.parent
+                / "dynalab"
+                / "handler"
+                / "handler.py.template"
+            )
 
             with template.open() as f:
                 content = f.read()

--- a/dynalab_cli/upload.py
+++ b/dynalab_cli/upload.py
@@ -11,12 +11,12 @@ from datetime import datetime
 from pathlib import Path
 
 import requests
-from requests_toolbelt.multipart import encoder
-from tqdm import tqdm
 
 from dynalab.config import DYNABENCH_API
 from dynalab_cli import BaseCommand
 from dynalab_cli.utils import AccessToken, SetupConfigHandler, get_task_submission_limit
+from requests_toolbelt.multipart import encoder
+from tqdm import tqdm
 
 
 class UploadCommand(BaseCommand):
@@ -112,7 +112,8 @@ class UploadCommand(BaseCommand):
                 print(
                     f"Failed to submit model {self.args.name} "
                     f"due to submission limit exceeded. No more than {threshold} "
-                    f"submissions allowed every {hr_diff} hours for task {config['task']}."
+                    f"submissions allowed every {hr_diff} hours for "
+                    f"task {config['task']}."
                 )
             else:
                 print(f"Failed to submit model due to: {ex}")
@@ -128,7 +129,11 @@ class UploadCommand(BaseCommand):
             )
         finally:
             os.makedirs(self.config_handler.submission_dir, exist_ok=True)
-            submission = self.config_handler.submission_dir / datetime.now().strftime("%b-%d-%Y-%H-%M-%S-") + tarball.name
+            submission = (
+                self.config_handler.submission_dir
+                / datetime.now().strftime("%b-%d-%Y-%H-%M-%S-")
+                + tarball.name
+            )
             shutil.move(tarball, submission)
             tmp_tarball_dir.cleanup()
             print(

--- a/dynalab_cli/upload.py
+++ b/dynalab_cli/upload.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import shutil
 import subprocess
 import tempfile
@@ -128,7 +127,7 @@ class UploadCommand(BaseCommand):
                 f"on Dynabench."
             )
         finally:
-            os.makedirs(self.config_handler.submission_dir, exist_ok=True)
+            self.config_handler.submission_dir.mkdir(exist_ok=True)
             submission = (
                 self.config_handler.submission_dir
                 / datetime.now().strftime("%b-%d-%Y-%H-%M-%S-")

--- a/dynalab_cli/upload.py
+++ b/dynalab_cli/upload.py
@@ -10,12 +10,12 @@ from datetime import datetime
 from pathlib import Path
 
 import requests
+from requests_toolbelt.multipart import encoder
+from tqdm import tqdm
 
 from dynalab.config import DYNABENCH_API
 from dynalab_cli import BaseCommand
 from dynalab_cli.utils import AccessToken, SetupConfigHandler, get_task_submission_limit
-from requests_toolbelt.multipart import encoder
-from tqdm import tqdm
 
 
 class UploadCommand(BaseCommand):

--- a/dynalab_cli/utils.py
+++ b/dynalab_cli/utils.py
@@ -280,7 +280,7 @@ class SetupConfigHandler:
     def write_exclude_filelist(self, outfile, model_name, exclude_model=False):
         def _write_exclude_entry_safe(file, f_obj):
             if (self.root_dir / file).exists():
-                f_obj.write(file + "\n")
+                f_obj.write(str(file) + "\n")
 
         config = self.load_config()
         with Path(outfile).open("w") as f:

--- a/dynalab_cli/utils.py
+++ b/dynalab_cli/utils.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
-import os
 import re
 import webbrowser
 from pathlib import Path
@@ -17,6 +16,7 @@ from dynalab.config import DYNABENCH_API, DYNABENCH_WEB
 class APIToken:
     def __init__(self):
         self.cred_path = (Path("~") / ".dynalab" / "secrets.json").expanduser()
+
     def save(self, token):
         dirname = self.cred_path.parent
         dirname.mkdir(exist_ok=True)
@@ -127,14 +127,14 @@ def get_task_submission_limit(task_code):
             if task["dynalab_hr_diff"] is not None:
                 hr_diff = task["dynalab_hr_diff"]
             if task["dynalab_threshold"] is not None:
-                threshold = task['dynalab_threshold']
+                threshold = task["dynalab_threshold"]
             return hr_diff, threshold
     return hr_diff, threshold
 
 
 # some file path utils
 def check_path(path, root_dir=".", is_file=True, allow_empty=True):
-    path=Path(path)
+    path = Path(path)
     if not path:
         return False
     if not path.exists():
@@ -147,7 +147,12 @@ def check_path(path, root_dir=".", is_file=True, allow_empty=True):
 
 
 def get_path_inside_rootdir(path, root_dir="."):
-    return Path(path).expanduser().resolve().relative_to(Path(root_dir).expanduser().resolve())
+    return (
+        Path(path)
+        .expanduser()
+        .resolve()
+        .relative_to(Path(root_dir).expanduser().resolve())
+    )
 
 
 def default_filename(key):
@@ -205,8 +210,8 @@ class SetupConfigHandler:
 
     def write_config(self, config):
         self.config_dir.mkdir(exist_ok=True)
-        config["checkpoint"]=str(config["checkpoint"])
-        config["handler"]=str(config["handler"])
+        config["checkpoint"] = str(config["checkpoint"])
+        config["handler"] = str(config["handler"])
         with self.config_path.open("w+") as f:
             f.write(json.dumps(config, indent=4))
 
@@ -250,9 +255,7 @@ class SetupConfigHandler:
                     files = config[key]
                     for f in files:
                         assert check_path(
-                            self.root_dir / f,
-                            root_dir=self.root_dir,
-                            allow_empty=False,
+                            self.root_dir / f, root_dir=self.root_dir, allow_empty=False
                         ), f"{key} path {f} is empty or not a valid path"
                         assert (
                             f not in excluded_files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # This is required to make sorting same as fbcode as all absolute imports
 # are considered third party there
 known_third_party = [
-    "requests"
+    "requests", "requests_toolbelt", "tqdm"
 ]
 skip_glob = "**/build/**"
 combine_as_imports = true


### PR DESCRIPTION
As per https://github.com/facebookresearch/dynalab/issues/114, the `pathlib` library handles POSIX vs Windows inter-operability for us.

This PR changes all `os.path` functions used to their corresponding `pathlib` functions, and fixes the bug(s) identified in https://github.com/facebookresearch/dynalab/issues/114

Note: I've been able to test `init`, `init --amend`, and `test --local` commands fairly thoroughly - however, I haven't been able to test `test` and `upload` commands (Permission Denied file in use errors, maybe my hardware just isn't enough to support the Docker storage space + memory requirements).

If there are errors arising from `pathlib` functions in `test` and `upload`, please let me know and I'll fix them.