### PR TITLE
chore: add third-party packages to isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # This is required to make sorting same as fbcode as all absolute imports
 # are considered third party there
 known_third_party = [
-    "requests"
+    "requests", "requests_toolbelt", "torchserve", "torch-model-archiver", "tqdm"
 ]
 skip_glob = "**/build/**"
 combine_as_imports = true


### PR DESCRIPTION
small chore, no files in main branch are affected by a re-lint but noticed the issue when working on https://github.com/facebookresearch/dynalab/pull/121 (specifically, this change was made by linter and passed tests https://github.com/kokrui/dynalab/blob/ccac1b5fce289b0d030990c5d29c06f327091515/dynalab_cli/upload.py#L13-L20)